### PR TITLE
Add local CI with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+        args: [--safe, --quiet, --line-length, "100"]
+        language_version: python3
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: "3.7.9"
+    hooks:
+      - id: flake8
+        args:
+          [
+            --count,
+            --select,
+            "E9,F63,F7,F82",
+            --show-source,
+            --statistics,
+            --max-complexity,
+            "10",
+            --max-line-length,
+            "100",
+          ]
+        language_version: python3

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ Check out examples of queries and how they are transformed in call to the FHIR a
 - [Get the number of patients currently in intensive care unit because of Coronavirus](examples/example3.md)
 - [Get clinical information about patients that were in intensive care unit because of Coronavirus](examples/example4.md)
 
+## Contributing
+
+The following commands on a terminal and in your virtual environment allow you to do some minimal local testing before each commit:
+
+```
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+If you ever want to delete them you just have to do:
+```
+pre-commit clean
+```
+
 ## Publish
 
 First, you need to have `twine` installedd


### PR DESCRIPTION
This PR proposes to add an additional feature to improve/facilitate the development of the FHIR2Dataset module :small_airplane: 

The goal of pre-commit hooks is to improve the quality of commits. This is achieved by making sure the local commits meet some (very formal) requirements:
* black
* flake8
(and normally you won't see any more flake8 commits :angel: )

This feature can be used by following the instructions on the README file