### PR TITLE
Ls/publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ Transform FHIR to dataset for ML applications
 
 ## FHIR2Dataset in Detail
 
-This project is still under development.
-
-This repo allows to make a SQL query on a FHIR API and to retrieve tabular data. 
+This repo allows to make a SQL query on a FHIR API and to retrieve tabular data.
 
 _FHIR2Dataset is still under active development!_
 
 ## Installation
+
 ### With pip
 
 `pip install fhir2dataset`
 
 ### From source
+
 After cloning this repository, you can install the required dependencies
 
 ```
@@ -24,7 +24,6 @@ npm install --prefix ./fhir2dataset/metadata
 ```
 
 For usage, refer to this [turorial](https://htmlpreview.github.io/?https://github.com/arkhn/FHIR2Dataset/blob/query_tests/examples/tutorial.html) and then this [Jupyer Notebook](examples/example.ipynb)
-
 
 ## Getting started
 
@@ -57,7 +56,7 @@ config_from_parser = parser.parse(sql_like_query)
 query.from_config(config_from_parser)
 query.execute()
 df = query.main_dataframe
-``` 
+```
 
 **JSON config file as entry**
 
@@ -73,44 +72,39 @@ query = Query(fhir_api_url, fhir_rules=fhir_rules)
 config.json :
 
 ```json
-{"select":{
-    "alias n°1":[
-        "a",
-        "b",
-        "c"
-    ],
-    "alias n°2":[
-        "a"
-    ]
-},
-"from":{
-    "alias n°1":"Resource type 1",
-    "alias n°2":"Resource type 2",
-    "alias n°3":"Resource type 3"
-},
-"join":{
-    "inner": {
-        "alias n°1":{
-            "d":"alias n°2"
-
-        },
-        "alias n°2":{
-            "b":"alias n°3"
-        }
-
-    }
-},
-"where":{
-    "alias n°2":{
-        "c":"value 1",
-        "d":"value 2"
+{
+    "select": {
+        "alias n°1": ["a", "b", "c"],
+        "alias n°2": ["a"]
     },
-    "alias n°3":{
-        "a":"value 3",
-        "b":"value 4"
+    "from": {
+        "alias n°1": "Resource type 1",
+        "alias n°2": "Resource type 2",
+        "alias n°3": "Resource type 3"
+    },
+    "join": {
+        "inner": {
+            "alias n°1": {
+                "d": "alias n°2"
+            },
+            "alias n°2": {
+                "b": "alias n°3"
+            }
+        }
+    },
+    "where": {
+        "alias n°2": {
+            "c": "value 1",
+            "d": "value 2"
+        },
+        "alias n°3": {
+            "a": "value 3",
+            "b": "value 4"
+        }
     }
-}}
+}
 ```
+
 ```
 # Enter in dirname the path of config.json
 filename_config = 'config.json'
@@ -122,7 +116,6 @@ query.from_config(config)
 query.execute()
 df = query.main_dataframe
 ```
-
 
 ## Examples
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 import os
 from setuptools import setup, find_packages
 from setuptools.command.build_py import build_py
+from setuptools.command.sdist import sdist
+
 from subprocess import call
 
 with open(
@@ -13,20 +15,26 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-class NPMInstall(build_py):
+class MyBuildCommand(build_py):
     def run(self):
         call(["npm", "install", "--prefix", "fhir2dataset/metadata"])
         build_py.run(self)
 
 
+class MySdistCommand(sdist):
+    def run(self):
+        call(["npm", "install", "--prefix", "fhir2dataset/metadata"])
+        sdist.run(self)
+
+
 requirements = read("requirements.txt").split()
 
 setup(
-    cmdclass={"build_py": NPMInstall},
+    cmdclass={"build_py": MyBuildCommand, "sdist": MySdistCommand},
     name="fhir2dataset",
     packages=find_packages(),
     include_package_data=True,
-    version="0.1.1-a1",
+    version="0.1.1-a2",
     license="Apache License 2.0",
     description="Transform FHIR to Dataset",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     name="fhir2dataset",
     packages=find_packages(),
     include_package_data=True,
-    version="0.1.1-a2",
+    version="0.1.2",
     license="Apache License 2.0",
     description="Transform FHIR to Dataset",
     long_description=long_description,


### PR DESCRIPTION
Some last changes so that the module created on PyPI contains the javascript dependencies.
I tested the new GitHub workflow on [test.pypi](https://test.pypi.org/project/fhir2dataset/#history), normally the 0.1.1a2 pre-release works well! 
You can test it by doing: 
```
pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple fhir2dataset==0.1.1a2
```
