### PR TITLE
Error joining two dataframes (pandas / merge / hashable)

### DIFF
--- a/fhir2dataset/query.py
+++ b/fhir2dataset/query.py
@@ -243,10 +243,14 @@ class Query:
             how = "inner"
 
         if alias_1 == alias_parent:
+            df_1 = df_1.explode(parent_on)
+            df_2 = df_2.explode(child_on)
             df_merged_inner = pd.merge(
                 left=df_1, right=df_2, left_on=parent_on, right_on=child_on, how=how
             )
         else:
+            df_1 = df_1.explode(child_on)
+            df_2 = df_2.explode(parent_on)
             df_merged_inner = pd.merge(
                 left=df_2, right=df_1, left_on=parent_on, right_on=child_on, how=how
             )


### PR DESCRIPTION
## Description
When a SQL query has a join on tables which keys are lists (due to FIHR format), the code outputs a pandas error (on dataframe merging). 
Fix #98 

## Fixes
Fix error when join two dataframes where pk/fn key values can be lists.

## Technical details
Solution is to explode list values into several similar rows in the dataframe.